### PR TITLE
Replace a const with a use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-const PI: f64 = std::f64::consts::PI;
+use std::f64::consts::PI;
 
 /// Projects a given LL coordinate at a specific zoom level into pixel screen-coordinates.
 ///


### PR DESCRIPTION
This would probably get optimised out anyway, but doing this is more idiomatic
