### PR TITLE
GH-4 Add from_ll_to_subpixel function.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "googleprojection"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Magnus Bergmark <magnus.bergmark@gmail.com>"]
 
 description = "Project world- or screen-space coordinates for use in Google Maps tiles (WebMercator)"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## Version 1.2.0 ##
+
+*   **New feature:** Added function `from_ll_to_subpixel`
+
+    This new function works like `from_ll_to_pixel` but without rounding to the nearest integers.
+
 ## Version 1.1.0 ##
 
 *   **New feature:** Project with a custom tile size.


### PR DESCRIPTION
For issue #4.

Added test matching other functions, as well as a test that covers the use case I am interested in, extending pixel-based boundaries around a lat/lng. The vec of data for `it_matches_google_maps_projection_extension` represents the North East corner of a bounding rectangle.